### PR TITLE
Fix ERROR:  column "record" does not exist

### DIFF
--- a/remove_ou_data/09_remove_bibs_stage_2.sql
+++ b/remove_ou_data/09_remove_bibs_stage_2.sql
@@ -94,7 +94,7 @@ DELETE FROM booking.resource_type WHERE record IN
     WHERE NOT EXISTS (select 1 from asset.call_number where record = x.record)
 );
 
-DELETE FROM metabib.display_entry WHERE record IN
+DELETE FROM metabib.display_entry WHERE source IN
 (
     SELECT record FROM esi.:vol_del_table x
     WHERE NOT EXISTS (select 1 from asset.call_number where record = x.record)


### PR DESCRIPTION
Change "record" to "souce" when deleting from metabib.display_entry in
remove_ou_data/09_remove_bibs_stage_2.sql, as the latter is the
correct column name.

Signed-off-by: Jason Stephenson <jason@sigio.com>