### PR TITLE
More remove ou deletes

### DIFF
--- a/remove_ou_data/02_remove_patron_extras.sql
+++ b/remove_ou_data/02_remove_patron_extras.sql
@@ -63,6 +63,9 @@ DELETE FROM actor.usr_address WHERE usr IN
 DELETE FROM actor.usr_message WHERE usr IN
 (SELECT id FROM actor.usr WHERE home_ou IN (SELECT (actor.org_unit_descendants(id)).id from actor.org_unit where shortname = :ou_to_del));
 
+DELETE FROM actor.usr_message WHERE sending_lib IN
+(SELECT (actor.org_unit_descendants(id)).id from actor.org_unit where shortname = :ou_to_del);
+
 DELETE FROM actor.stat_cat_entry_usr_map WHERE target_usr IN 
 (SELECT id FROM actor.usr WHERE home_ou IN (SELECT (actor.org_unit_descendants(id)).id from actor.org_unit where shortname = :ou_to_del));
 

--- a/remove_ou_data/04_remove_circ.sql
+++ b/remove_ou_data/04_remove_circ.sql
@@ -32,6 +32,12 @@ DELETE FROM action.circulation WHERE usr IN
 DELETE FROM action.circulation WHERE circ_staff IN
 (SELECT id FROM actor.usr WHERE home_ou IN (SELECT (actor.org_unit_descendants(id)).id from actor.org_unit where shortname = :ou_to_del));
 
+UPDATE action.circulation c
+SET parent_circ = NULL
+FROM action.circulation p
+WHERE p.id = c.parent_circ AND p.circ_lib IN
+(SELECT (actor.org_unit_descendants(id)).id from actor.org_unit where shortname = :ou_to_del);
+
 DELETE FROM action.circulation WHERE circ_lib IN
 (SELECT (actor.org_unit_descendants(id)).id from actor.org_unit where shortname = :ou_to_del);
 


### PR DESCRIPTION
This branch adds an update and a delete that I needed to do when removing one of our old member libraries in a test database.

The first commit adds an update to NULL the parent_circ on renewals of circulations that will be deleted, but the renewals will not. This principally affects renewals that happen at a library other than the initial checkout library when the initial checkout library will be deleted. These could be in-person, phone, or OPAC (depending on settings) renewals.

The second commit adds a delete on actor.usr_message when the sending_lib is going to be deleted, but the user isn't being deleted. This seems to happen when the library to be deleted added a message to another library's patron.