### PR TITLE
add a Pg function to produce simple diffs of MARC XML

### DIFF
--- a/sql/base/01-marc.sql
+++ b/sql/base/01-marc.sql
@@ -1,3 +1,42 @@
+CREATE OR REPLACE FUNCTION migration_tools.marc_diff (marc1 TEXT, marc2 TEXT)
+ RETURNS TEXT
+ LANGUAGE plperlu
+AS $function$
+use strict;
+use warnings;
+
+use MARC::Record;
+use MARC::File::XML (BinaryEncoding => 'utf8');
+use Text::Diff;
+
+binmode(STDOUT, ':utf8');
+binmode(STDERR, ':utf8');
+
+my $marc_xml1 = shift;
+my $marc_xml2 = shift;
+my $marc1;
+my $marc2;
+
+eval {
+    $marc1 = MARC::Record->new_from_xml($marc_xml1);
+};
+if ($@) {
+    return "ERROR: Could not parse first MARC record: $@";
+}
+eval {
+    $marc2 = MARC::Record->new_from_xml($marc_xml2);
+};
+if ($@) {
+    return "ERROR: Could not parse second MARC record: $@";
+}
+
+
+my $diff = diff(\($marc1->as_formatted), \($marc2->as_formatted));
+
+return $diff;
+
+$function$;
+
 DROP FUNCTION IF EXISTS migration_tools.strip_subfield(TEXT,CHAR(3),CHAR(1));
 CREATE OR REPLACE FUNCTION migration_tools.strip_subfield(marc TEXT, tag CHAR(3), subfield CHAR(1))
  RETURNS TEXT

--- a/sql/base/MANIFEST
+++ b/sql/base/MANIFEST
@@ -18,6 +18,7 @@ grep -i 'CREATE OR REPLACE FUNCTION' *.sql | perl -ne 'if (/^(.+?):.*(migration_
 # 01-marc.sql:migration_tools.get_marc_tags_filtered
 # 01-marc.sql:migration_tools.insert_tags
 # 01-marc.sql:migration_tools.make_stub_bib
+# 01-marc.sql:migration_tools.marc_diff
 # 01-marc.sql:migration_tools.marc_parses
 # 01-marc.sql:migration_tools.marc_set_tag
 # 01-marc.sql:migration_tools.merge_marc_fields
@@ -131,6 +132,7 @@ grep -i 'CREATE OR REPLACE FUNCTION' *.sql | perl -ne 'if (/^(.+?):.*(migration_
 # 09-misc.sql:migration_tools.is_blank
 # 09-misc.sql:migration_tools.null_empty_columns
 # 09-misc.sql:migration_tools.null_empty_lcolumns
+# 09-misc.sql:migration_tools.safer_truncate
 # 10-staging.sql:migration_tools.simple_import_new_rows_by_value
 # 10-staging.sql:migration_tools.split_rows_on_column_with_delimiter
 # 10-staging.sql:migration_tools.stage_not_applicable_asset_stat_cats


### PR DESCRIPTION
Invoked as `SELECT evergreen.marc_diff(marc1, marc1)`, where marc1 and marc2 are text values containing MARCXML blobs.

The diff is based on the human-readable version of the records as produced by `MARC::Record->as_formatted`.

Requires the CPAN module `Text::Diff`, instalable via `libtext-diff-perl` on Debian-ish systems.